### PR TITLE
Update loggingUtil.py

### DIFF
--- a/src/endstone_wmctcore/utils/loggingUtil.py
+++ b/src/endstone_wmctcore/utils/loggingUtil.py
@@ -22,8 +22,7 @@ def log(self: "WMCTPlugin", message, type):
     config = load_config()
     db = UserDB("wmctcore_users.db") 
 
-    discord_thread = threading.Thread(target=discordRelay, args=(message, type))
-    discord_thread.start()
+    threading.Thread(target=discordRelay, args=(message, type)).start()
 
     # Load config tags once
     config_tags = set(config["modules"]["game_logging"].get("custom_tags", []))
@@ -31,13 +30,23 @@ def log(self: "WMCTPlugin", message, type):
     players_to_notify = []
     for player in self.server.online_players:
         user = db.get_online_user(player.xuid)
-        if has_log_perms(user.internal_rank) or config_tags.intersection(set(player.scoreboard_tags) or player.is_op):
+        # build a real set of tags (not a bool)
+        tags = set(player.scoreboard_tags or [])
+
+        # check perms, custom-tag overlap, or OP status
+        if (has_log_perms(user.internal_rank)
+            or (config_tags & tags)
+            or player.is_op
+           ):
             if db.enabled_logs(player.xuid):
                 players_to_notify.append(player)
 
     # Send messages to players asynchronously
     if players_to_notify:
-        threading.Thread(target=send_messages, args=(players_to_notify, message, db)).start()
+        threading.Thread(
+            target=send_messages,
+            args=(players_to_notify, message, db)
+        ).start()
 
     db.close_connection() 
     return False


### PR DESCRIPTION
fix the annoying ass error message:
```
[2025-06-21 21:17:31.808 ERROR] [Server] Could not pass event PlayerCommandEvent to plugin wmctcore v1.1.0. TypeError: 'bool' object is not iterable
[2025-06-21 21:17:31.808 ERROR] [Server] 
[2025-06-21 21:17:31.808 ERROR] [Server] At:
[2025-06-21 21:17:31.808 ERROR] [Server]   /home/container/plugins/.local/lib/python3.13/site-packages/endstone_wmctcore/utils/loggingUtil.py(34): log
[2025-06-21 21:17:31.808 ERROR] [Server]   /home/container/plugins/.local/lib/python3.13/site-packages/endstone_wmctcore/events/command_processes.py(22): handle_command_preprocess
[2025-06-21 21:17:31.808 ERROR] [Server]   /home/container/plugins/.local/lib/python3.13/site-packages/endstone_wmctcore/wmctcore.py(74): on_player_command_preprocess
```